### PR TITLE
Add support for columnheaders

### DIFF
--- a/lmd/request.go
+++ b/lmd/request.go
@@ -633,6 +633,9 @@ func (req *Request) ParseRequestHeaderLine(line *string) (err error) {
 	case "keepalive":
 		err = parseOnOff(&req.KeepAlive, line, matched[1])
 		return
+	case "columnheaders":
+		err = parseOnOff(&req.SendColumnsHeader, line, matched[1])
+		return
 	default:
 		err = fmt.Errorf("bad request: unrecognized header %s", *line)
 		return


### PR DESCRIPTION
Livestatus supports columnHeaders as request parameter.
LMD has an internal option "sendcolumnheader" which can extend this.