### PR TITLE
Add support for Limit:0 filter

### DIFF
--- a/lmd/request.go
+++ b/lmd/request.go
@@ -601,7 +601,7 @@ func (req *Request) ParseRequestHeaderLine(line *string) (err error) {
 		err = parseSortHeader(&req.Sort, matched[1])
 		return
 	case "limit":
-		err = parseIntHeader(&req.Limit, matched[0], matched[1], 1)
+		err = parseIntHeader(&req.Limit, matched[0], matched[1], 0)
 		return
 	case "offset":
 		err = parseIntHeader(&req.Offset, matched[0], matched[1], 0)


### PR DESCRIPTION
Livestatus accepts Limit:0. LMD throws error, though it can be neglected. This fix addresses this.