### PR TITLE
Add support for And/Or: 0 

### DIFF
--- a/lmd/filter.go
+++ b/lmd/filter.go
@@ -423,8 +423,14 @@ func ParseStats(value string, line *string, table string, stack *[]*Filter) (err
 // It returns any error encountered.
 func ParseFilterOp(header string, value string, line *string, stack *[]*Filter) (err error) {
 	num, cerr := strconv.Atoi(value)
-	if cerr != nil || num < 1 {
+	if cerr != nil || num < 0 {
 		err = fmt.Errorf("bad request: %s must be a positive number in: %s", header, *line)
+		return
+	}
+	if num == 0 {
+		if log.IsV(2) {
+			log.Debugf("Ignoring %s as value is not positive", *line)
+		}
 		return
 	}
 	stackLen := len(*stack)


### PR DESCRIPTION
And/Or are used to combine filters.
LMD throws error with a value 0.
However livestatus accepts a value of 0, which is internally discarded though.
This fix addresses this issue.