### PR TITLE
wrapped_json output not proper

### DIFF
--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -1078,7 +1078,7 @@ func (p *Peer) parseResult(req *Request, resBytes *[]byte) (result [][]interface
 	if req.OutputFormat == "wrapped_json" {
 		dataBytes, dataType, _, jErr := jsonparser.Get(*resBytes, "columns")
 		if dataType == jsonparser.Array {
-			var columns []string
+			var columns [][]string
 			err = json.Unmarshal(dataBytes, &columns)
 			if err != nil {
 				log.Debugf("[%s] column header parse error: %s", p.Name, err.Error())

--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -1081,7 +1081,7 @@ func (p *Peer) parseResult(req *Request, resBytes *[]byte) (result [][]interface
 			var columns [][]string
 			err = json.Unmarshal(dataBytes, &columns)
 			if err != nil {
-				log.Debugf("[%s] column header parse error: %s", p.Name, err.Error())
+				log.Debugf("[%s] columns header parse error: %s", p.Name, err.Error())
 			} else {
 				p.PeerLock.Lock()
 				p.Status["LastColumns"] = columns[0]

--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -1084,7 +1084,7 @@ func (p *Peer) parseResult(req *Request, resBytes *[]byte) (result [][]interface
 				log.Debugf("[%s] column header parse error: %s", p.Name, err.Error())
 			} else {
 				p.PeerLock.Lock()
-				p.Status["LastColumns"] = columns
+				p.Status["LastColumns"] = columns[0]
 				p.PeerLock.Unlock()
 			}
 		}

--- a/lmd/response.go
+++ b/lmd/response.go
@@ -559,9 +559,11 @@ func (res *Response) WrappedJSON() ([]byte, error) {
 	enc.Encode(res.Failed)
 	if sendColumnsHeader {
 		buf.Write([]byte("\n,\"columns\":"))
+		buf.Write([]byte("["))
 		enc.Encode(cols)
+		buf.Write([]byte("]"))
 	}
-	buf.Write([]byte(fmt.Sprintf("\n,\"total_count\":%d}}", res.ResultTotal)))
+	buf.Write([]byte(fmt.Sprintf("\n,\"total_count\":%d}", res.ResultTotal)))
 	return buf.Bytes(), nil
 }
 


### PR DESCRIPTION
The wrapped_json output does not have proper count of starting and closing braces. 
This causes an improper json decode result.
This fix addresses this issue. 