### PR TITLE
Offset row id by other backend optional fields

### DIFF
--- a/lmd/objects.go
+++ b/lmd/objects.go
@@ -217,11 +217,14 @@ func (t *Table) GetInitialKeys(flags OptionalFlags) (keys []string) {
 
 // GetDynamicColumns returns a list of all dynamic columns along with their indexes.
 func (t *Table) GetDynamicColumns(flags OptionalFlags) (keys []string, indexes []int) {
+	offset := 0
 	for _, col := range t.Columns {
 		if col.Update == DynamicUpdate {
 			if col.Optional == NoFlags || flags&col.Optional != 0 {
 				keys = append(keys, col.Name)
-				indexes = append(indexes, col.Index)
+				indexes = append(indexes, col.Index-offset)
+			} else {
+				offset++
 			}
 		}
 	}


### PR DESCRIPTION
Correct regression on shinken backend introduced by https://github.com/sni/lmd/commit/0458719aa69eda4e008e990b96ee12bb8acea0a7

```
[2018-07-27 13:13:24][Error][peer.go:2397] [Monitoring Site A] Panic: runtime error: index out of range
[2018-07-27 13:13:24][Error][peer.go:2398] [Monitoring Site A] goroutine 20 [running]:
runtime/debug.Stack(0xc42019e000, 0x8fa3bf, 0xe)
        /usr/lib/golang/src/runtime/debug/stack.go:24 +0xa7
main.logPanicExitPeer(0xc4202400c0)
        /home/a2683/cvs/lmd-nrd/lmd/peer.go:2398 +0x12f
panic(0x874900, 0xb5e030)
        /usr/lib/golang/src/runtime/panic.go:491 +0x283
main.(*Peer).UpdateDeltaTableServices(0xc4202400c0, 0xc42031e160, 0xa6, 0x0, 0x0)
        /home/a2683/cvs/lmd-nrd/lmd/peer.go:798 +0x1027
main.(*Peer).UpdateDeltaTableFullScan(0xc4202400c0, 0xc4201d55f0, 0xc42001e940, 0x40, 0x1, 0xc42001e940, 0x40)
        /home/a2683/cvs/lmd-nrd/lmd/peer.go:867 +0xb08
main.(*Peer).UpdateDeltaTableServices(0xc4202400c0, 0xc42001e940, 0x40, 0x0, 0x0)
        /home/a2683/cvs/lmd-nrd/lmd/peer.go:764 +0xf86
main.(*Peer).UpdateDeltaTables(0xc4202400c0, 0x8f7f40)
        /home/a2683/cvs/lmd-nrd/lmd/peer.go:666 +0xb0f
main.(*Peer).periodicUpdate(0xc4202400c0, 0xc42014be7e, 0xc42014be80)
        /home/a2683/cvs/lmd-nrd/lmd/peer.go:391 +0x370
main.(*Peer).updateLoop(0xc4202400c0)
        /home/a2683/cvs/lmd-nrd/lmd/peer.go:322 +0x2f8
main.(*Peer).Start.func1(0xc4202400c0)
        /home/a2683/cvs/lmd-nrd/lmd/peer.go:223 +0x59
created by main.(*Peer).Start
        /home/a2683/cvs/lmd-nrd/lmd/peer.go:220 +0x17f
```