### PR TITLE
Add default sorting option

### DIFF
--- a/lmd/request.go
+++ b/lmd/request.go
@@ -670,9 +670,13 @@ func parseIntHeader(field *int, header string, value string, minValue int) (err 
 func parseSortHeader(field *[]*SortField, value string) (err error) {
 	args := ""
 	tmp := strings.SplitN(value, " ", 3)
-	if len(tmp) < 2 {
+	if len(tmp) < 1 {
 		err = errors.New("bad request: invalid sort header, must be 'Sort: <field> <asc|desc>' or 'Sort: custom_variables <name> <asc|desc>'")
 		return
+	}
+	if len(tmp) == 1 {
+		// Add default sorting option
+		tmp = append(tmp, "asc")
 	}
 	if len(tmp) == 3 {
 		if tmp[0] != "custom_variables" && tmp[0] != "host_custom_variables" {


### PR DESCRIPTION
In case user does not provide sorting option, a default sorting asc/desc can be applied.
Again this is required for naemon livestatus when it queries with option "Sort: next_check", it fails because of argument number restriction.