### PR TITLE
Make peers aware of the columns for the DataTables

### DIFF
--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -1525,10 +1525,16 @@ func (p *Peer) CreateObjectByType(table *Table) (err error) {
 
 	keys := table.GetInitialKeys(p.Flags)
 
+	columnsMap := make(map[int]int)
+	for i, peerCol := range keys {
+		tableColIndex := table.ColumnsIndex[peerCol]
+		columnsMap[tableColIndex] = i
+	}
+
 	// complete virtual table ends here
 	if len(keys) == 0 || table.Virtual {
 		p.DataLock.Lock()
-		p.Tables[table.Name] = DataTable{Table: table, Data: make([][]interface{}, 1), Refs: nil, Index: nil, ColumnsMap: make(map[int]int)}
+		p.Tables[table.Name] = DataTable{Table: table, Data: make([][]interface{}, 1), Refs: nil, Index: nil, ColumnsMap: columnsMap}
 		p.DataLock.Unlock()
 		return
 	}
@@ -1570,12 +1576,6 @@ func (p *Peer) CreateObjectByType(table *Table) (err error) {
 		for i := range res {
 			lastUpdate[i] = now
 		}
-	}
-
-	columnsMap := make(map[int]int)
-	for i, peerCol := range keys {
-		tableColIndex := table.ColumnsIndex[peerCol]
-		columnsMap[tableColIndex] = i
 	}
 
 	p.DataLock.Lock()

--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -2492,6 +2492,7 @@ func (p *Peer) getError() string {
 
 func (p *Peer) gatherResultRows(res *Response, table *Table, data *[][]interface{}, numPerRow int, indexes *[]int) (int, *[][]interface{}) {
 	req := res.Request
+	columns := p.Tables[req.Table].ColumnsMap
 	refs := p.Tables[req.Table].Refs
 	result := make([][]interface{}, 0)
 
@@ -2527,8 +2528,8 @@ Rows:
 				// reference columns come after the non-ref columns
 				if i >= len(*row) {
 					resRow[k] = p.GetRowValue(&(res.Columns[k]), row, j, table, &refs)
-				} else {
-					resRow[k] = (*row)[i]
+				} else if col, ok := columns[i]; ok {
+					resRow[k] = (*row)[col]
 				}
 			}
 			// fill null values with something useful


### PR DESCRIPTION
This pull request adds a field called `ColumnsMap` to the DataTable object that is used by peers during initialization. This field is a map of type `map[int]int`, and it maps a ColumnIndex (as described by the Table, such as the numbers you find in `Table.ColumnIndexes` or in `Column.Index`, to the actual index to access when extracting data from rows in the DataTable data (`DataTable.Data`).

## Why

As explained in #41, this is a required step to avoid offsetting errors, because if the table has optional fields that are not present for a peer of a particular kind, each row in the datatable will have less columns than the sum of static and dynamic columns defined in the Table object backing that particular datatable.

If a column that has an index greater than the index of an optional column that has been stripped for the datatable because of this is accessed, the column index for the DataTable data will not actually match the column index available in the ColumnIndex for the Table definition

Therefore, I need to have some data structure that I can use to query the following question: _"which index of a datatable data row holds the value for the column whose index in the object table definition is X?"_, and then access that particular column.

## Alternate proposals

I considered having a more complex map, or an index similar to the ColumnsIndex used in Table, which uses objects of type Columns, but I think that would make the model more complicated with redundant data.

I also considered letting the peers compute the actual indexes on runtime instead of caching data as a field. Something like moving the call to BuildResponseIndexes to compute the indexes values from response.go to peer.go:

https://github.com/sni/lmd/blob/7302d294350e6612ea8b61a0047d6487f21fe7d0/lmd/response.go#L87

So when a request is received, rather than passing the numerical indexes of the columns to `(*Response).BuildLocalResponse`, the columns are still unresolved strings. It's up to the peer to map the column string into an appropiate column value, similar to how `(*Table).GetInitialKeys` does so:

https://github.com/sni/lmd/blob/0ffe74514e122f3da45543109842be22c943e317/lmd/objects.go#L213-L222

However, I believe that this adds some extra overhead to each request as it now has to compute a lot of columns and that could make the request slower to be handled.

Anyway, since it's my first patch and because this change updates the data model for the program, I'm open to suggestions or requests for change on this.