### PR TITLE
Do not ignore Limit: 0

### DIFF
--- a/lmd/http.go
+++ b/lmd/http.go
@@ -157,7 +157,8 @@ func parseRequestDataToRequest(requestData map[string]interface{}) (req *Request
 
 	// Limit
 	if val, ok := requestData["limit"]; ok {
-		req.Limit = int(val.(float64))
+		req.Limit = new(int)
+		*req.Limit = int(val.(float64))
 	}
 
 	// Filter String in livestatus syntax

--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -2583,7 +2583,7 @@ Rows:
 		found++
 		// check if we have enough result rows already
 		// we still need to count how many result we would have...
-		if limit > 0 && found > limit {
+		if limit >= 0 && found > limit {
 			continue Rows
 		}
 
@@ -2698,11 +2698,13 @@ func createLocalStatsCopy(stats *[]*Filter) []*Filter {
 	return localStats
 }
 func optimizeResultLimit(req *Request, table *Table) (limit int) {
-	if req.Limit > 0 && table.IsDefaultSortOrder(&req.Sort) {
-		limit = req.Limit
+	if req.Limit != nil && table.IsDefaultSortOrder(&req.Sort) {
+		limit = *req.Limit
 		if req.Offset > 0 {
 			limit += req.Offset
 		}
+	} else {
+		limit = -1
 	}
 	return
 }

--- a/lmd/request.go
+++ b/lmd/request.go
@@ -24,7 +24,7 @@ type Request struct {
 	FilterStr           string
 	Stats               []*Filter
 	StatsResult         map[string][]*Filter
-	Limit               int
+	Limit               *int
 	Offset              int
 	Sort                []*SortField
 	ResponseFixed16     bool
@@ -155,8 +155,8 @@ func (req *Request) String() (str string) {
 	if len(req.Backends) > 0 {
 		str += "Backends: " + strings.Join(req.Backends, " ") + "\n"
 	}
-	if req.Limit > 0 {
-		str += fmt.Sprintf("Limit: %d\n", req.Limit)
+	if req.Limit != nil {
+		str += fmt.Sprintf("Limit: %d\n", *req.Limit)
 	}
 	if req.Offset > 0 {
 		str += fmt.Sprintf("Offset: %d\n", req.Offset)
@@ -493,8 +493,8 @@ func (req *Request) buildDistributedRequestData(subBackends []string) (requestDa
 	// Limit
 	// An upper limit is used to make sorting possible
 	// Offset is 0 for sub-request (sorting)
-	if req.Limit != 0 {
-		requestData["limit"] = req.Limit + req.Offset
+	if req.Limit != nil && *req.Limit != 0 {
+		requestData["limit"] = *req.Limit + req.Offset
 	}
 
 	// Sort order
@@ -605,7 +605,8 @@ func (req *Request) ParseRequestHeaderLine(line *string) (err error) {
 		err = parseSortHeader(&req.Sort, matched[1])
 		return
 	case "limit":
-		err = parseIntHeader(&req.Limit, matched[0], matched[1], 0)
+		req.Limit = new(int)
+		err = parseIntHeader(req.Limit, matched[0], matched[1], 0)
 		return
 	case "offset":
 		err = parseIntHeader(&req.Offset, matched[0], matched[1], 0)

--- a/lmd/request_test.go
+++ b/lmd/request_test.go
@@ -58,7 +58,7 @@ func TestRequestHeaderTable(t *testing.T) {
 func TestRequestHeaderLimit(t *testing.T) {
 	buf := bufio.NewReader(bytes.NewBufferString("GET hosts\nLimit: 10\n"))
 	req, _, _ := NewRequest(buf)
-	if err := assertEq(10, req.Limit); err != nil {
+	if err := assertEq(10, *req.Limit); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/lmd/response.go
+++ b/lmd/response.go
@@ -311,8 +311,8 @@ func (res *Response) PostProcessing() {
 	}
 
 	// apply request limit
-	if res.Request.Limit > 0 && res.Request.Limit < len(res.Result) {
-		res.Result = res.Result[0:res.Request.Limit]
+	if res.Request.Limit != nil && *res.Request.Limit >= 0 && *res.Request.Limit < len(res.Result) {
+		res.Result = res.Result[0:*res.Request.Limit]
 	}
 
 	// final calculation of stats querys


### PR DESCRIPTION
Livestatus respond to a query with 'Limit: 0', by providing all the
columns for the object type, but no actual objects.

Before this commit, LMD would ignore Limit: 0 and return all the found
objects.

This commit ensures that setting Limit: 0, results in LMD
responding only with the object type columns.

Signed-off-by: Jacob Hansen <jhansen@op5.com>