### PR TITLE
Implement DataEncoding option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ EXTERNAL_DEPS = \
 	github.com/mvdan/unparam \
 	github.com/mdempsky/unconvert \
 	honnef.co/go/tools/cmd/staticcheck \
+	github.com/paulrosania/go-charset/charset \
+	github.com/paulrosania/go-charset/data \
 
 
 all: deps fmt build

--- a/lmd.ini.example
+++ b/lmd.ini.example
@@ -57,6 +57,10 @@ SkipSSLCheck = 0
 # Uncomment to export runtime statistics in prometheus format
 #ListenPrometheus = "127.0.0.1:8080"
 
+# Sets the encoding of the output. Valid options are utf8, latin1
+# Defaults to utf8
+DataEncoding = "utf8"
+
 # use tcp connections
 [[Connections]]
 name   = "Monitoring Site A"

--- a/lmd/main.go
+++ b/lmd/main.go
@@ -97,6 +97,7 @@ type Config struct {
 	IdleTimeout         int64
 	IdleInterval        int64
 	StaleBackendTimeout int
+	DataEncoding        string
 }
 
 // PeerMap contains a map of available remote peers.
@@ -146,6 +147,9 @@ var flagProfile string
 var once sync.Once
 var mainSignalChannel chan os.Signal
 var lastMainRestart = time.Now().Unix()
+
+// DataEncoding contains the desired output encoding
+var DataEncoding string
 
 // initialize objects structure
 func init() {
@@ -197,6 +201,7 @@ func mainLoop(mainSignalChannel chan os.Signal) (exitCode int) {
 	setDefaults(&LocalConfig)
 	setVerboseFlags(&LocalConfig)
 	InitLogging(&LocalConfig)
+	setDataEncoding(&LocalConfig)
 
 	osSignalChannel := make(chan os.Signal, 1)
 	signal.Notify(osSignalChannel, syscall.SIGHUP)
@@ -569,6 +574,18 @@ func setDefaults(conf *Config) {
 	}
 	if conf.StaleBackendTimeout <= 0 {
 		conf.StaleBackendTimeout = 30
+	}
+}
+
+func setDataEncoding(conf *Config) {
+	if strings.ToLower(conf.DataEncoding) == "latin1" {
+		DataEncoding = "latin1"
+	} else if strings.ToLower(conf.DataEncoding) == "utf8" {
+		DataEncoding = "utf8"
+	} else {
+		log.Warnf("Invalid encoding: %s, assuming utf8", conf.DataEncoding)
+		log.Warnf("%s", "Valid data encodings are: utf8, latin1")
+		DataEncoding = "utf8"
 	}
 }
 


### PR DESCRIPTION
Livestatus supports several DataEncoding options, utf-8, latin1 and
mixed. This commit adds an option in LMD in order to support latin1 as
the output encoding.

A couple of notes:

1 - Livestatus actually seem to output escaped chars i.e for UTF-8: 

```
# echo "GET hosts\nColumns: name\nOutputFormat: json" | unixcat livestatus
[["h\u00f6stname_t\u00e4sting"],
["m\u00f6nitor"]]

# echo "GET hosts\nColumns: name\nOutputFormat: json" | unixcat lmd
[["höstname_tästing"]
,["mönitor"]
]
```

A similar thing we do for latin1. This means the livestatus behavior is not 100% replicated

2 - the data_encoding in the livestatus settings must be correct, but this was true even before this patch (i.e. setting utf8 as the data_encoding setting in livestatus if the nagios/naemon files are actually in latin1 means wrong output is generated)