### PR TITLE
Use more of the test dataset

### DIFF
--- a/lmd/a_helper_test.go
+++ b/lmd/a_helper_test.go
@@ -168,8 +168,14 @@ func prepareTmpDataHostService(dataFolder string, tempFolder string, table *Tabl
 	if name == "hosts" {
 		nameIndex := table.GetColumn("name").Index
 		for x := 1; x <= numHosts; x++ {
-			newObj := make([]interface{}, len(last))
-			copy(newObj, last)
+			var newObj []interface{}
+			if x >= num {
+				newObj = make([]interface{}, len(last))
+				copy(newObj, last)
+			} else {
+				newObj = make([]interface{}, len(raw[x]))
+				copy(newObj, raw[x])
+			}
 			newObj[nameIndex] = fmt.Sprintf("%s_%d", "testhost", x)
 			newData = append(newData, newObj)
 		}
@@ -177,10 +183,18 @@ func prepareTmpDataHostService(dataFolder string, tempFolder string, table *Tabl
 	if name == "services" {
 		nameIndex := table.GetColumn("host_name").Index
 		descIndex := table.GetColumn("description").Index
+		count := 0
 		for x := 1; x <= numHosts; x++ {
 			for y := 1; y <= numServices/numHosts; y++ {
-				newObj := make([]interface{}, len(last))
-				copy(newObj, last)
+				var newObj []interface{}
+				count = count + 1
+				if count >= num {
+					newObj = make([]interface{}, len(last))
+					copy(newObj, last)
+				} else {
+					newObj = make([]interface{}, len(raw[count]))
+					copy(newObj, raw[count])
+				}
 				newObj[nameIndex] = fmt.Sprintf("%s_%d", "testhost", x)
 				newObj[descIndex] = fmt.Sprintf("%s_%d", "testsvc", y)
 				newData = append(newData, newObj)

--- a/lmd/nodes_test.go
+++ b/lmd/nodes_test.go
@@ -46,10 +46,10 @@ func TestNodeManager(t *testing.T) {
 	if err = assertEq(40, int(res[0][0].(float64))); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq(0.24065613746999998, res[0][1]); err != nil {
+	if err = assertEq(0.14149327278193, res[0][1]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq(9.6262454988, res[0][2]); err != nil {
+	if err = assertEq(5.6597309112772, res[0][2]); err != nil {
 		t.Error(err)
 	}
 
@@ -58,16 +58,16 @@ func TestNodeManager(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = assertEq("testhost_1", res[0][0]); err != nil {
+	if err = assertEq("testhost_10", res[1][0]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq("tomcat", res[0][1]); err != nil {
+	if err = assertEq("test host 5", res[1][1]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq(4.0, res[0][2]); err != nil {
+	if err = assertEq(4.0, res[1][2]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq(0.24065613747, res[0][3]); err != nil {
+	if err = assertEq(0.049920082092, res[1][3]); err != nil {
 		t.Error(err)
 	}
 

--- a/lmd/request_test.go
+++ b/lmd/request_test.go
@@ -148,7 +148,7 @@ func TestRequestListFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := assertEq("testhost_1", res[0][0]); err != nil {
+	if err := assertEq("testhost_10", res[0][0]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -301,16 +301,16 @@ func TestRequestStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = assertEq(9.6262454988, res[0][0]); err != nil {
+	if err = assertEq(5.6597309112772, res[0][0]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq(0.24065613746999998, res[0][1]); err != nil {
+	if err = assertEq(0.14149327278193, res[0][1]); err != nil {
 		t.Error(err)
 	}
 	if err = assertEq(float64(1), res[0][2]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq(4.010726, res[0][3]); err != nil {
+	if err = assertEq(4.031151, res[0][3]); err != nil {
 		t.Error(err)
 	}
 	if err = assertEq(float64(40), res[0][4]); err != nil {
@@ -340,7 +340,7 @@ func TestRequestStatsGroupBy(t *testing.T) {
 	if err = assertEq("testhost_1", res[0][0]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq(0.24065613747, res[1][1]); err != nil {
+	if err = assertEq(0.049920082092, res[1][1]); err != nil {
 		t.Error(err)
 	}
 
@@ -354,10 +354,10 @@ func TestRequestStatsGroupBy(t *testing.T) {
 	if err = assertEq("testhost_1", res[0][0]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq("tomcat", res[1][1]); err != nil {
+	if err = assertEq("test host 5", res[1][1]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq(0.24065613747, res[1][2]); err != nil {
+	if err = assertEq(0.049920082092, res[1][2]); err != nil {
 		t.Error(err)
 	}
 
@@ -443,7 +443,7 @@ func TestRequestBrokenColumns(t *testing.T) {
 	if err = assertEq("testhost_1", res[0][0]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq("tomcat", res[0][1]); err != nil {
+	if err = assertEq("Business Process: Test Business Process", res[0][1]); err != nil {
 		t.Error(err)
 	}
 
@@ -460,13 +460,13 @@ func TestRequestGroupByTable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = assertEq(10, len(res)); err != nil {
+	if err = assertEq(17, len(res)); err != nil {
 		t.Fatal(err)
 	}
 	if err = assertEq("testhost_1", res[0][0]); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq("127.0.0.2", res[0][5]); err != nil {
+	if err = assertEq("Business Process", res[0][5]); err != nil {
 		t.Error(err)
 	}
 
@@ -524,7 +524,7 @@ func TestRequestSort(t *testing.T) {
 	if err = assertEq(5, len(res)); err != nil {
 		t.Error(err)
 	}
-	if err = assertEq("testhost_4", res[0][0]); err != nil {
+	if err = assertEq("testhost_1", res[0][0]); err != nil {
 		t.Error(err)
 	}
 


### PR DESCRIPTION
Previously, when generating the host and service dataset, only the last
host/service defined in the test data would be used.

This commit ensures that we use the actual dataset, and if more hosts or
services than defined are needed, then we duplicate the last defined
test object (as before).

Given that the test dataset used have changed, a bunch of the expected
values in the tests needed to be adjusted.

Signed-off-by: Jacob Hansen <jhansen@op5.com>