### PR TITLE
Revert "Revert "Add service info columns to the host table (#58)" (#60)"

### DIFF
--- a/lmd/objects.go
+++ b/lmd/objects.go
@@ -677,6 +677,7 @@ func NewHostsTable() (t *Table) {
 	t.AddColumn("process_performance_data", DynamicUpdate, IntCol, "Whether processing of performance data is enabled (0/1)")
 	t.AddColumn("retry_interval", StaticUpdate, IntCol, "Number of basic interval lengths between checks when retrying after a soft error")
 	t.AddColumn("scheduled_downtime_depth", DynamicUpdate, IntCol, "The number of downtimes this host is currently in")
+	t.AddColumn("services", StaticUpdate, StringListCol, "The services associated with the host")
 	t.AddColumn("state", DynamicUpdate, IntCol, "The current state of the host (0: up, 1: down, 2: unreachable)")
 	t.AddColumn("state_type", DynamicUpdate, IntCol, "The current state of the host (0: up, 1: down, 2: unreachable)")
 	t.AddColumn("staleness", DynamicUpdate, FloatCol, "Staleness indicator for this host")
@@ -699,6 +700,8 @@ func NewHostsTable() (t *Table) {
 	t.AddOptColumn("got_business_rule", DynamicUpdate, IntCol, Shinken, "Whether the host state is an business rule based host or not (0/1)")
 	t.AddOptColumn("parent_dependencies", DynamicUpdate, StringCol, Shinken, "List of the dependencies (logical, network or business one) of this host.")
 
+	t.AddColumn("services_with_info", RefNoUpdate, VirtCol, "The services, including info, that is associated with the host")
+	t.AddColumn("services_with_state", RefNoUpdate, VirtCol, "The services, including state info, that is associated with the host")
 	t.AddColumn("lmd_last_cache_update", RefNoUpdate, VirtCol, "Timestamp of the last LMD update of this object.")
 	t.AddColumn("peer_key", RefNoUpdate, VirtCol, "Id of this peer")
 	t.AddColumn("peer_name", RefNoUpdate, VirtCol, "Name of this peer")

--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -2192,6 +2192,35 @@ func (p *Peer) GetVirtRowComputedValue(col *ResultColumn, row *[]interface{}, ro
 		} else {
 			value = 0
 		}
+	case "services_with_state":
+		fallthrough
+	case "services_with_info":
+		// test
+		servicesIndex := table.ColumnsIndex["services"]
+		services := (*row)[servicesIndex]
+		hostnameIndex := table.ColumnsIndex["name"]
+		hostName := (*row)[hostnameIndex].(string)
+		var res []interface{}
+		for _, v := range services.([]interface{}) {
+			var serviceValue []interface{}
+			var serviceID strings.Builder
+
+			serviceID.WriteString(hostName)
+			serviceID.WriteString(";")
+			serviceID.WriteString(v.(string))
+
+			serviceInfo := p.Tables["services"].Index[serviceID.String()]
+			stateIndex := p.Tables["services"].Table.GetColumn("state").Index
+			checkedIndex := p.Tables["services"].Table.GetColumn("has_been_checked").Index
+
+			serviceValue = append(serviceValue, v.(string), serviceInfo[stateIndex], serviceInfo[checkedIndex])
+			if col.Name == "services_with_info" {
+				outputIndex := p.Tables["services"].Table.GetColumn("plugin_output").Index
+				serviceValue = append(serviceValue, serviceInfo[outputIndex])
+			}
+			res = append(res, serviceValue)
+		}
+		value = res
 	case "configtool":
 		if _, ok := p.Status["ConfigTool"]; ok {
 			value = p.Status["ConfigTool"]

--- a/lmd/response.go
+++ b/lmd/response.go
@@ -57,7 +57,9 @@ var VirtKeyMap = map[string]VirtKeyMapTupel{
 	"federation_name":         {Index: -24, Key: "", Type: StringListCol},
 	"federation_addr":         {Index: -25, Key: "", Type: StringListCol},
 	"federation_type":         {Index: -26, Key: "", Type: StringListCol},
-	EMPTY:                     {Index: -27, Key: "", Type: StringCol},
+	"services_with_state":     {Index: -27, Key: "", Type: StringListCol},
+	"services_with_info":      {Index: -28, Key: "", Type: StringListCol},
+	EMPTY:                     {Index: -29, Key: "", Type: StringCol},
 }
 
 // Response contains the livestatus response data as long with some meta data


### PR DESCRIPTION
This reverts commit a9525f1243ad7f9f3a5e25424c0f60d1a12e5cf8 (which reverts the service info columns commit).

The actually issue we had was not related to this commit, but due to
incompatibilities between our naemon-livestatus and LMD (dependency columns). Therefore this
commit can safely be included again.

Apologies for the confusion.