### PR TITLE
Comments with info

### DIFF
--- a/lmd/objects.go
+++ b/lmd/objects.go
@@ -702,6 +702,7 @@ func NewHostsTable() (t *Table) {
 
 	t.AddColumn("services_with_info", RefNoUpdate, VirtCol, "The services, including info, that is associated with the host")
 	t.AddColumn("services_with_state", RefNoUpdate, VirtCol, "The services, including state info, that is associated with the host")
+	t.AddColumn("comments_with_info", RefNoUpdate, VirtCol, "A list of all comments of the host with id, author and comment")
 	t.AddColumn("lmd_last_cache_update", RefNoUpdate, VirtCol, "Timestamp of the last LMD update of this object.")
 	t.AddColumn("peer_key", RefNoUpdate, VirtCol, "Id of this peer")
 	t.AddColumn("peer_name", RefNoUpdate, VirtCol, "Name of this peer")
@@ -843,6 +844,7 @@ func NewServicesTable() (t *Table) {
 
 	t.AddRefColumn(HOSTS, "host", "name", "host_name")
 
+	t.AddColumn("comments_with_info", RefNoUpdate, VirtCol, "A list of all comments of the host with id, author and comment")
 	t.AddColumn("lmd_last_cache_update", RefNoUpdate, VirtCol, "Timestamp of the last LMD update of this object.")
 	t.AddColumn("peer_key", RefNoUpdate, VirtCol, "Id of this peer")
 	t.AddColumn("peer_name", RefNoUpdate, VirtCol, "Name of this peer")

--- a/lmd/objects.go
+++ b/lmd/objects.go
@@ -843,6 +843,7 @@ func NewServicesTable() (t *Table) {
 	t.AddOptColumn("parent_dependencies", DynamicUpdate, StringCol, Shinken, "List of the dependencies (logical, network or business one) of this service.")
 
 	t.AddRefColumn(HOSTS, "host", "name", "host_name")
+	t.AddColumn("host_comments_with_info", RefNoUpdate, VirtCol, "A list of all comments of the host with id, author and comment")
 
 	t.AddColumn("comments_with_info", RefNoUpdate, VirtCol, "A list of all comments of the host with id, author and comment")
 	t.AddColumn("lmd_last_cache_update", RefNoUpdate, VirtCol, "Timestamp of the last LMD update of this object.")
@@ -899,6 +900,7 @@ func NewCommentsTable() (t *Table) {
 	t.AddColumn("service_description", StaticUpdate, StringCol, "Description of the service (also used as key)")
 
 	t.AddRefColumn(HOSTS, "host", "name", "host_name")
+	t.AddColumn("host_comments_with_info", RefNoUpdate, VirtCol, "A list of all comments of the host with id, author and comment")
 	t.AddRefColumn(SERVICES, "service", "description", "service_description")
 
 	t.AddColumn("peer_key", RefNoUpdate, VirtCol, "Id of this peer")
@@ -926,6 +928,7 @@ func NewDowntimesTable() (t *Table) {
 	t.AddColumn("service_description", StaticUpdate, StringCol, "Description of the service (also used as key)")
 
 	t.AddRefColumn(HOSTS, "host", "name", "host_name")
+	t.AddColumn("host_comments_with_info", RefNoUpdate, VirtCol, "A list of all comments of the host with id, author and comment")
 	t.AddRefColumn(SERVICES, "service", "description", "service_description")
 
 	t.AddColumn("peer_key", RefNoUpdate, VirtCol, "Id of this peer")
@@ -970,6 +973,7 @@ func NewHostsByGroupTable() (t *Table) {
 	t.AddColumn("hostgroup_name", StaticUpdate, StringCol, "Host group name")
 
 	t.AddRefColumn(HOSTS, "", "name", "name")
+	t.AddColumn("host_comments_with_info", RefNoUpdate, VirtCol, "A list of all comments of the host with id, author and comment")
 	t.AddRefColumn("hostgroups", "hostgroup", "name", "hostgroup_name")
 
 	t.AddColumn("peer_key", RefNoUpdate, VirtCol, "Id of this peer")
@@ -987,6 +991,7 @@ func NewServicesByGroupTable() (t *Table) {
 	t.AddColumn("servicegroup_name", StaticUpdate, StringCol, "Service group name")
 
 	t.AddRefColumn(HOSTS, "host", "name", "host_name")
+	t.AddColumn("host_comments_with_info", RefNoUpdate, VirtCol, "A list of all comments of the host with id, author and comment")
 	t.AddRefColumn(SERVICES, "", "description", "description")
 	t.AddRefColumn("servicegroups", "servicegroup", "name", "servicegroup_name")
 
@@ -1005,6 +1010,7 @@ func NewServicesByHostgroupTable() (t *Table) {
 	t.AddColumn("hostgroup_name", StaticUpdate, StringCol, "Host group name")
 
 	t.AddRefColumn(HOSTS, "host", "name", "host_name")
+	t.AddColumn("host_comments_with_info", RefNoUpdate, VirtCol, "A list of all comments of the host with id, author and comment")
 	t.AddRefColumn(SERVICES, "", "description", "description")
 	t.AddRefColumn("hostgroups", "hostgroup", "name", "hostgroup_name")
 

--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -2221,6 +2221,27 @@ func (p *Peer) GetVirtRowComputedValue(col *ResultColumn, row *[]interface{}, ro
 			res = append(res, serviceValue)
 		}
 		value = res
+	case "comments_with_info":
+		commentsIndex := table.ColumnsIndex["comments"]
+		comments := (*row)[commentsIndex]
+		var res []interface{}
+		for _, commentID := range comments.([]interface{}) {
+			var commentWithInfo []interface{}
+
+			commentIDStr := strconv.FormatFloat(commentID.(float64), 'f', 0, 64)
+			comment := p.Tables["comments"].Index[commentIDStr]
+
+			authorIndex := p.Tables["comments"].Table.GetColumn("author").Index
+			commentIndex := p.Tables["comments"].Table.GetColumn("comment").Index
+
+			commentWithInfo = append(commentWithInfo, commentID, comment[authorIndex], comment[commentIndex])
+			res = append(res, commentWithInfo)
+		}
+		if len(res) > 0 {
+			value = res
+		} else {
+			value = []string{}
+		}
 	case "configtool":
 		if _, ok := p.Status["ConfigTool"]; ok {
 			value = p.Status["ConfigTool"]

--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -2221,9 +2221,20 @@ func (p *Peer) GetVirtRowComputedValue(col *ResultColumn, row *[]interface{}, ro
 			res = append(res, serviceValue)
 		}
 		value = res
+	case "host_comments_with_info":
+		fallthrough
 	case "comments_with_info":
-		commentsIndex := table.ColumnsIndex["comments"]
-		comments := (*row)[commentsIndex]
+		var comments interface{}
+		if col.Name == "host_comments_with_info" {
+			hostNameIndex := table.ColumnsIndex["host_name"]
+			hostName := (*row)[hostNameIndex]
+			host := p.Tables["hosts"].Index[hostName.(string)]
+			commentsIndex := p.Tables["hosts"].Table.GetColumn("comments").Index
+			comments = host[commentsIndex]
+		} else {
+			commentsIndex := table.ColumnsIndex["comments"]
+			comments = (*row)[commentsIndex]
+		}
 		var res []interface{}
 		for _, commentID := range comments.([]interface{}) {
 			var commentWithInfo []interface{}

--- a/lmd/response.go
+++ b/lmd/response.go
@@ -59,7 +59,8 @@ var VirtKeyMap = map[string]VirtKeyMapTupel{
 	"federation_type":         {Index: -26, Key: "", Type: StringListCol},
 	"services_with_state":     {Index: -27, Key: "", Type: StringListCol},
 	"services_with_info":      {Index: -28, Key: "", Type: StringListCol},
-	EMPTY:                     {Index: -29, Key: "", Type: StringCol},
+	"comments_with_info":      {Index: -29, Key: "", Type: StringListCol},
+	EMPTY:                     {Index: -30, Key: "", Type: StringCol},
 }
 
 // Response contains the livestatus response data as long with some meta data

--- a/lmd/response.go
+++ b/lmd/response.go
@@ -59,8 +59,9 @@ var VirtKeyMap = map[string]VirtKeyMapTupel{
 	"federation_type":         {Index: -26, Key: "", Type: StringListCol},
 	"services_with_state":     {Index: -27, Key: "", Type: StringListCol},
 	"services_with_info":      {Index: -28, Key: "", Type: StringListCol},
-	"comments_with_info":      {Index: -29, Key: "", Type: StringListCol},
-	EMPTY:                     {Index: -30, Key: "", Type: StringCol},
+	"host_comments_with_info": {Index: -29, Key: "", Type: StringListCol},
+	"comments_with_info":      {Index: -30, Key: "", Type: StringListCol},
+	EMPTY:                     {Index: -31, Key: "", Type: StringCol},
 }
 
 // Response contains the livestatus response data as long with some meta data


### PR DESCRIPTION
This PR adds the comments_with_info column to host and services.

Also the host_comments_with_info is added to all the relevant tables. I didn't manage to figure out a good way to have this value "inherited" down, with the rest of the host fields (using AddRefColumn). Instead they are explicitly added to each relevant table.