### PR TITLE
Services_with_* should return empty list if empty

### DIFF
--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -2220,7 +2220,11 @@ func (p *Peer) GetVirtRowComputedValue(col *ResultColumn, row *[]interface{}, ro
 			}
 			res = append(res, serviceValue)
 		}
-		value = res
+		if len(res) > 0 {
+			value = res
+		} else {
+			value = []string{}
+		}
 	case "host_comments_with_info":
 		fallthrough
 	case "comments_with_info":


### PR DESCRIPTION
If a host does not have any services, services_with_state and
services_with_info LMD currently returns `null`. Livestatus on the otherhand
returns an empty list instead.

This commit makes the output consistent with livestatus.