### PR TITLE
correct LMD hang with incorrect COMMAND timestamp

### DIFF
--- a/lmd/request.go
+++ b/lmd/request.go
@@ -297,6 +297,10 @@ func (req *Request) ParseRequestAction(firstLine *string) (valid bool, err error
 	// or a command
 	if strings.HasPrefix(*firstLine, "COMMAND ") {
 		matched := reRequestCommand.FindStringSubmatch(*firstLine)
+		if len(matched) < 1 {
+			err = fmt.Errorf("bad request: %s", *firstLine)
+			return
+		}
 		req.Command = matched[0]
 		valid = true
 		return

--- a/lmd/request_test.go
+++ b/lmd/request_test.go
@@ -709,6 +709,14 @@ func TestCommands(t *testing.T) {
 		t.Error(err2)
 	}
 
+	res, err = peer.QueryString("COMMAND [123.456] test_broken\n\n")
+	if err == nil {
+		t.Fatal("expected error for broken command")
+	}
+	if err2 := assertEq(err.Error(), "bad request: COMMAND [123.456] test_broken"); err2 != nil {
+		t.Error(err2)
+	}
+
 	if err := StopTestPeer(peer); err != nil {
 		panic(err.Error())
 	}

--- a/lmd/request_test.go
+++ b/lmd/request_test.go
@@ -709,7 +709,7 @@ func TestCommands(t *testing.T) {
 		t.Error(err2)
 	}
 
-	res, err = peer.QueryString("COMMAND [123.456] test_broken\n\n")
+	_, err = peer.QueryString("COMMAND [123.456] test_broken\n\n")
 	if err == nil {
 		t.Fatal("expected error for broken command")
 	}


### PR DESCRIPTION
Sending a command with an incorrect timestamp hang LMD. This patch make it reject the command