### PR TITLE
Change servicegroups members to InterfaceList

### DIFF
--- a/lmd/objects.go
+++ b/lmd/objects.go
@@ -497,7 +497,7 @@ func NewServicegroupsTable() (t *Table) {
 	t = &Table{Name: "servicegroups", PrimaryKey: []string{"name"}, DefaultSort: []string{"name"}}
 	t.AddColumn("action_url", Static, StringCol, "An optional URL to custom notes or actions on the service group")
 	t.AddColumn("alias", Static, StringCol, "An alias of the service group")
-	t.AddColumn("members", Static, StringListCol, "A list of all members of the service group as host/service pairs")
+	t.AddColumn("members", Static, InterfaceListCol, "A list of all members of the service group as host/service pairs")
 	t.AddColumn("name", Static, StringCol, "The name of the service group")
 	t.AddColumn("notes", Static, StringCol, "Optional additional notes about the service group")
 	t.AddColumn("notes_url", Static, StringCol, "An optional URL to further notes on the service group")


### PR DESCRIPTION
The members column of servicegroups where previously defined as a
`StringListCol`. This resulted in an incorrect format, where it would be
impossible to distinguish the hostname from the service description if
either had a space in it.

Livestatus would output the member as: `["monitor","System load average"]`
whereas it would LMD would output it as: `"[monitor System load average]"`

By setting the servicegroup members column to `InterfaceListCol` we
correct the output to be in line with Livestatus.