### PR TITLE
Add support column name: <table>_<colum-name>

### DIFF
--- a/lmd/filter.go
+++ b/lmd/filter.go
@@ -633,16 +633,23 @@ func (f *Filter) MatchCustomVar(value map[string]string) bool {
 	return f.MatchString(&val)
 }
 
-// some broken clients request service_description instead of just description from the services table
+// some broken clients request <table>_column instead of just column
 // be nice to them as well...
 func fixBrokenClientsRequestColumn(columnName *string, table string) bool {
 	fixedColumnName := *columnName
 
 	switch table {
-	case "services":
-		fixedColumnName = strings.TrimPrefix(fixedColumnName, "service_")
-	case "hosts":
+	case "hostsbygroup":
 		fixedColumnName = strings.TrimPrefix(fixedColumnName, "host_")
+	case "servicesbygroup", "servicesbyhostgroup":
+		fixedColumnName = strings.TrimPrefix(fixedColumnName, "service_")
+	case "status":
+		fixedColumnName = strings.TrimPrefix(fixedColumnName, "status_")
+	default:
+		var tablePrefix strings.Builder
+		tablePrefix.WriteString(strings.TrimSuffix(table, "s"))
+		tablePrefix.WriteString("_")
+		fixedColumnName = strings.TrimPrefix(fixedColumnName, tablePrefix.String())
 	}
 
 	if _, ok := Objects.Tables[table].ColumnsIndex[fixedColumnName]; ok {

--- a/lmd/request_test.go
+++ b/lmd/request_test.go
@@ -880,3 +880,57 @@ func TestRequestSites(t *testing.T) {
 		panic(err.Error())
 	}
 }
+
+/* Tests that getting columns based on <table>_<colum-name> works */
+func TestTableNameColName(t *testing.T) {
+	peer := StartTestPeer(1, 2, 2)
+	PauseTestPeers(peer)
+
+	if err := assertEq(1, len(PeerMap)); err != nil {
+		t.Error(err)
+	}
+
+	res, _, err := peer.QueryString("GET hosts\nColumns: host_name\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = assertEq("testhost_1", (*res)[0][0]); err != nil {
+		t.Error(err)
+	}
+
+	res, _, err = peer.QueryString("GET hostgroups\nColumns: hostgroup_name\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = assertEq("Everything", (*res)[0][0]); err != nil {
+		t.Error(err)
+	}
+
+	res, _, err = peer.QueryString("GET hostgroups\nColumns: hostgroup_name\nFilter: hostgroup_name = host_1\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = assertEq("host_1", (*res)[0][0]); err != nil {
+		t.Error(err)
+	}
+
+	res, _, err = peer.QueryString("GET hostsbygroup\nColumns: host_name\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = assertEq("testhost_1", (*res)[0][0]); err != nil {
+		t.Error(err)
+	}
+
+	res, _, err = peer.QueryString("GET servicesbygroup\nColumns: service_description\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = assertEq("testsvc_1", (*res)[0][0]); err != nil {
+		t.Error(err)
+	}
+
+	if err := StopTestPeer(peer); err != nil {
+		panic(err.Error())
+	}
+}


### PR DESCRIPTION
Livestatus supports querying column names by prefixing the <table>_ with
the plural s removed. This commit adds support for this in LMD as well.

Signed-off-by: Jacob Hansen <jhansen@op5.com>