### PR TITLE
Add members_with_state column to group tables

### DIFF
--- a/lmd/column.go
+++ b/lmd/column.go
@@ -52,6 +52,7 @@ var VirtColumnList = []VirtColumnMapEntry{
 	{Name: "comments", ResolvFunc: VirtColComments},
 	{Name: "comments_with_info", ResolvFunc: VirtColComments},
 	{Name: "downtimes", ResolvFunc: VirtColDowntimes},
+	{Name: "members_with_state", ResolvFunc: VirtColMembersWithState},
 	{Name: "empty", ResolvFunc: func(_ *DataRow, _ *Column) interface{} { return "" }}, // return empty string as placeholder for nonexisting columns
 }
 

--- a/lmd/objects.go
+++ b/lmd/objects.go
@@ -378,6 +378,8 @@ func NewHostgroupsTable() (t *Table) {
 	t.AddPeerInfoColumn("lmd_last_cache_update", IntCol, "Timestamp of the last LMD update of this object")
 	t.AddPeerInfoColumn("peer_key", StringCol, "Id of this peer")
 	t.AddPeerInfoColumn("peer_name", StringCol, "Name of this peer")
+
+	t.AddExtraColumn("members_with_state", VirtStore, None, InterfaceListCol, NoFlags, "A list of all host names that are members of the hostgroup together with state and has_been_checked")
 	return
 }
 
@@ -514,6 +516,8 @@ func NewServicegroupsTable() (t *Table) {
 	t.AddPeerInfoColumn("lmd_last_cache_update", IntCol, "Timestamp of the last LMD update of this object")
 	t.AddPeerInfoColumn("peer_key", StringCol, "Id of this peer")
 	t.AddPeerInfoColumn("peer_name", StringCol, "Name of this peer")
+
+	t.AddExtraColumn("members_with_state", VirtStore, None, InterfaceListCol, NoFlags, "A list of all members of the service group with state and has_been_checked")
 	return
 }
 

--- a/lmd/request_test.go
+++ b/lmd/request_test.go
@@ -934,3 +934,49 @@ func TestTableNameColName(t *testing.T) {
 		panic(err.Error())
 	}
 }
+
+func TestMembersWithState(t *testing.T) {
+	peer := StartTestPeer(1, 2, 9)
+	PauseTestPeers(peer)
+
+	if err := assertEq(1, len(PeerMap)); err != nil {
+		t.Error(err)
+	}
+
+	res, _, err := peer.QueryString("GET hostgroups\nColumns: members_with_state\nFilter: name = host_1\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value := (*res)[0][0].([]interface{})[0].([]interface{})
+	if err := assertEq("testhost_1", value[0]); err != nil {
+		t.Error(err)
+	}
+	if err := assertEq(0., value[1]); err != nil {
+		t.Error(err)
+	}
+	if err := assertEq(1., value[2]); err != nil {
+		t.Error(err)
+	}
+
+	res, _, err = peer.QueryString("GET servicegroups\nColumns: members_with_state\nFilter: name = svc4\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value = (*res)[0][0].([]interface{})[0].([]interface{})
+	if err := assertEq("testhost_2", value[0]); err != nil {
+		t.Error(err)
+	}
+	if err := assertEq("testsvc_4", value[1]); err != nil {
+		t.Error(err)
+	}
+	if err := assertEq(0., value[2]); err != nil {
+		t.Error(err)
+	}
+	if err := assertEq(1., value[3]); err != nil {
+		t.Error(err)
+	}
+
+	if err := StopTestPeer(peer); err != nil {
+		panic(err.Error())
+	}
+}


### PR DESCRIPTION
This commit adds the virtual column members_with_state to the hostgroup
and servicegroup tables, as supported by Livestatus.

Signed-off-by: Jacob Hansen <jhansen@op5.com>