### PR TITLE
Change exceptions columns to InterfaceListCol

### DIFF
--- a/lmd/objects.go
+++ b/lmd/objects.go
@@ -173,11 +173,11 @@ func NewTimeperiodsTable() (t *Table) {
 
 	// naemon specific
 	t.AddExtraColumn("days", LocalStore, Static, InterfaceListCol, Naemon, "days")
-	t.AddExtraColumn("exceptions_calendar_dates", LocalStore, Static, StringListCol, Naemon, "exceptions_calendar_dates")
-	t.AddExtraColumn("exceptions_month_date", LocalStore, Static, StringListCol, Naemon, "exceptions_month_date")
-	t.AddExtraColumn("exceptions_month_day", LocalStore, Static, StringListCol, Naemon, "exceptions_month_day")
-	t.AddExtraColumn("exceptions_month_week_day", LocalStore, Static, StringListCol, Naemon, "exceptions_month_week_day")
-	t.AddExtraColumn("exceptions_week_day", LocalStore, Static, StringListCol, Naemon, "exceptions_week_day")
+	t.AddExtraColumn("exceptions_calendar_dates", LocalStore, Static, InterfaceListCol, Naemon, "exceptions_calendar_dates")
+	t.AddExtraColumn("exceptions_month_date", LocalStore, Static, InterfaceListCol, Naemon, "exceptions_month_date")
+	t.AddExtraColumn("exceptions_month_day", LocalStore, Static, InterfaceListCol, Naemon, "exceptions_month_day")
+	t.AddExtraColumn("exceptions_month_week_day", LocalStore, Static, InterfaceListCol, Naemon, "exceptions_month_week_day")
+	t.AddExtraColumn("exceptions_week_day", LocalStore, Static, InterfaceListCol, Naemon, "exceptions_week_day")
 	t.AddExtraColumn("exclusions", LocalStore, Static, StringListCol, Naemon, "exclusions")
 	t.AddExtraColumn("id", LocalStore, Static, IntCol, Naemon, "The id of the timeperiods")
 


### PR DESCRIPTION
The exceptions in the timeperiods table were incorrectly formatted in
LMD due to the type incorrectly being set to StringListCol. This commit
changes the type to InterfaceListCol which brings the output back in
line with Livestatus.

LMD output prior to this patch:

[["map[swday:0 swday_offset:1 ewday:0 ewday_offset:1 skip_interval:0 ...

Livestatus output:
[[{"swday":0,"swday_offset":1,"ewday":0,"ewday_offset":1,"skip_interval":0 ...

Signed-off-by: Jacob Hansen <jhansen@op5.com>