### PR TITLE
Add support for Negate header

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,3 +43,4 @@ issues:
     - "cyclomatic complexity .* of func `.*ParseRequestHeaderLine` is high"
     - "cyclomatic complexity .* of func `.*Less` is high"
     - "cyclomatic complexity .* of func `matchStringListFilter` is high"
+    - "cyclomatic complexity .* of func `.*String` is high"

--- a/lmd/a_helper_test.go
+++ b/lmd/a_helper_test.go
@@ -43,6 +43,13 @@ func assertEq(exp, got interface{}) error {
 	return nil
 }
 
+func assertNeq(exp, got interface{}) error {
+	if reflect.DeepEqual(exp, got) {
+		return fmt.Errorf("\n%#v\nIs equal to\n%#v", exp, got)
+	}
+	return nil
+}
+
 func assertLike(exp string, got string) error {
 	regex, err := regexp.Compile(exp)
 	if err != nil {

--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -2325,7 +2325,11 @@ Rows:
 		row := store.Data[j]
 		// does our filter match?
 		for i := range req.Filter {
-			if !row.MatchFilter(req.Filter[i]) {
+			if req.Negate {
+				if row.MatchFilter(req.Filter[i]) {
+					continue Rows
+				}
+			} else if !row.MatchFilter(req.Filter[i]) {
 				continue Rows
 			}
 		}
@@ -2359,7 +2363,11 @@ Rows:
 		row := store.Data[j]
 		// does our filter match?
 		for i := range req.Filter {
-			if !row.MatchFilter(req.Filter[i]) {
+			if req.Negate {
+				if row.MatchFilter(req.Filter[i]) {
+					continue Rows
+				}
+			} else if !row.MatchFilter(req.Filter[i]) {
 				continue Rows
 			}
 		}

--- a/lmd/request.go
+++ b/lmd/request.go
@@ -47,6 +47,7 @@ type Request struct {
 	WaitConditionNegate bool
 	KeepAlive           bool
 	AuthUser            string
+	Negate              bool
 }
 
 // SortDirection can be either Asc or Desc
@@ -229,6 +230,9 @@ func (req *Request) String() (str string) {
 	}
 	if req.WaitConditionNegate {
 		str += fmt.Sprintf("WaitConditionNegate\n")
+	}
+	if req.Negate {
+		str += fmt.Sprintf("Negate:\n")
 	}
 	if req.AuthUser != "" {
 		str += fmt.Sprintf("AuthUser: %s\n", req.AuthUser)
@@ -698,6 +702,12 @@ func (req *Request) ParseRequestHeaderLine(line []byte) (err error) {
 		return
 	case "waitconditionnegate":
 		req.WaitConditionNegate = true
+		return
+	case "negate":
+		if len(req.Filter) == 0 && req.FilterStr == "" {
+			err = fmt.Errorf("no Filter: header to negate")
+		}
+		req.Negate = true
 		return
 	case "keepalive":
 		err = parseOnOff(&req.KeepAlive, args)


### PR DESCRIPTION
This commit adds support for the Negate header. This can be used
together with filters to provide a negated filter result.