### PR TITLE
Correctly handle negate header in filter groups

### DIFF
--- a/lmd/datarow.go
+++ b/lmd/datarow.go
@@ -623,10 +623,16 @@ func (d *DataRow) MatchFilter(filter *Filter) bool {
 			Regexp:    filter.Regexp,
 			IsEmpty:   filter.IsEmpty,
 			CustomTag: filter.CustomTag,
+			Negate:    filter.Negate,
+		}
+		if f.Negate {
+			return !f.Match(d)
 		}
 		return f.Match(d)
 	}
-
+	if filter.Negate {
+		return !filter.Match(d)
+	}
 	return filter.Match(d)
 }
 

--- a/lmd/filter.go
+++ b/lmd/filter.go
@@ -50,6 +50,7 @@ type Filter struct {
 	Regexp     *regexp.Regexp
 	CustomTag  string
 	IsEmpty    bool
+	Negate     bool
 
 	// or a group of filters
 	Filter        []*Filter
@@ -150,6 +151,9 @@ func (f *Filter) String(prefix string) (str string) {
 	default:
 		str = fmt.Sprintf("Stats: %s %s\n", f.StatsType.String(), f.Column.Name)
 	}
+	if f.Negate {
+		str += fmt.Sprintf("%s\n", "Negate:")
+	}
 	return
 }
 
@@ -235,6 +239,7 @@ func ParseFilter(value []byte, table TableName, stack *[]*Filter) (err error) {
 	filter := &Filter{
 		Operator: op,
 		Column:   col,
+		Negate:   false,
 	}
 
 	err = filter.setFilterValue(string(tmp[2]))
@@ -434,6 +439,14 @@ func ParseFilterOp(op GroupOperator, value []byte, stack *[]*Filter) (err error)
 	*stack = make([]*Filter, 0, len(remainingStack)+1)
 	*stack = append(*stack, remainingStack...)
 	*stack = append(*stack, stackedFilter)
+	return
+}
+
+// ParseFilterNegate sets the last filter group to be negated
+func ParseFilterNegate(stack *[]*Filter) (err error) {
+	stackLen := len(*stack)
+	filter := (*stack)[stackLen-1]
+	filter.Negate = true
 	return
 }
 

--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -2384,11 +2384,7 @@ Rows:
 		row := store.Data[j]
 		// does our filter match?
 		for i := range req.Filter {
-			if req.Negate {
-				if row.MatchFilter(req.Filter[i]) {
-					continue Rows
-				}
-			} else if !row.MatchFilter(req.Filter[i]) {
+			if !row.MatchFilter(req.Filter[i]) {
 				continue Rows
 			}
 		}
@@ -2422,11 +2418,7 @@ Rows:
 		row := store.Data[j]
 		// does our filter match?
 		for i := range req.Filter {
-			if req.Negate {
-				if row.MatchFilter(req.Filter[i]) {
-					continue Rows
-				}
-			} else if !row.MatchFilter(req.Filter[i]) {
+			if !row.MatchFilter(req.Filter[i]) {
 				continue Rows
 			}
 		}

--- a/lmd/request.go
+++ b/lmd/request.go
@@ -47,7 +47,6 @@ type Request struct {
 	WaitConditionNegate bool
 	KeepAlive           bool
 	AuthUser            string
-	Negate              bool
 }
 
 // SortDirection can be either Asc or Desc
@@ -230,9 +229,6 @@ func (req *Request) String() (str string) {
 	}
 	if req.WaitConditionNegate {
 		str += fmt.Sprintf("WaitConditionNegate\n")
-	}
-	if req.Negate {
-		str += fmt.Sprintf("Negate:\n")
 	}
 	if req.AuthUser != "" {
 		str += fmt.Sprintf("AuthUser: %s\n", req.AuthUser)
@@ -706,8 +702,9 @@ func (req *Request) ParseRequestHeaderLine(line []byte) (err error) {
 	case "negate":
 		if len(req.Filter) == 0 && req.FilterStr == "" {
 			err = fmt.Errorf("no Filter: header to negate")
+			return
 		}
-		req.Negate = true
+		err = ParseFilterNegate(&req.Filter)
 		return
 	case "keepalive":
 		err = parseOnOff(&req.KeepAlive, args)

--- a/lmd/request_test.go
+++ b/lmd/request_test.go
@@ -1052,11 +1052,30 @@ func TestNegate(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = assertEq(9, len(*res)); err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	for _, host := range *res {
 		if err = assertNeq("testhost_1", host[0]); err != nil {
+			t.Error(err)
+		}
+	}
+
+	res, _, err = peer.QueryString("GET services\nColumns: host_name state\nFilter: host_name ~ testhost_1\nFilter: state = 0\nNegate:\nAnd: 2\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = assertEq(1, len(*res)); err != nil {
+		t.Error(err)
+	}
+
+	for _, host := range *res {
+		if err = assertEq("testhost_1", host[0]); err != nil {
+			t.Error(err)
+		}
+
+		if err = assertNeq("0", host[1]); err != nil {
 			t.Error(err)
 		}
 	}


### PR DESCRIPTION
Previously if the negate header was included, the whole filter result
would be negated. However in some queries only part of the filter should
be negated, for example:

GET hosts
Filter: alias ~ test
Filter: state = 0
Negate:
And: 2

In this case, we would negate the full query, whereas in Livestatus
only the state filter would be negated.

This commit brings the behavior in line with Livestatus.