### PR TITLE
Fixes for passing golangci-lint 1.18.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,9 @@ linters-settings:
     settings:
       rangeValCopy:
         sizeThreshold: 32
+  funlen:
+    lines: 150
+    statements: 120
 linters:
   enable-all: true
   disable:
@@ -31,7 +34,6 @@ linters:
     - dupl
     - goconst
   fast: false
-
 issues:
   max-same-issues: 0
   exclude-use-default: true

--- a/lmd/listener.go
+++ b/lmd/listener.go
@@ -364,7 +364,6 @@ func (l *Listener) LocalListenerHTTP(httpType string, listen string) {
 		WriteTimeout: 5 * time.Second,
 	}
 	server.Serve(c)
-
 }
 
 func getTLSListenerConfig(localConfig *Config) (config *tls.Config, err error) {

--- a/lmd/main.go
+++ b/lmd/main.go
@@ -391,7 +391,6 @@ func initializePeers(localConfig *Config, waitGroupPeers *sync.WaitGroup, waitGr
 	nodeAccessor = NewNodes(localConfig, nodeAddresses, nodeListenAddress, waitGroupInit, shutdownChannel)
 	nodeAccessor.Initialize() // starts peers in single mode
 	nodeAccessor.Start()      // nodes loop starts/stops peers in cluster mode
-
 }
 
 func checkFlags() {

--- a/lmd/nodes.go
+++ b/lmd/nodes.go
@@ -177,7 +177,6 @@ func (n *Nodes) Initialize() {
 	if n.IsClustered() {
 		n.checkNodeAvailability()
 	}
-
 }
 
 // Start starts the loop that periodically checks which nodes are online.
@@ -215,7 +214,6 @@ func (n *Nodes) loop() {
 			return
 		case <-ticker.C:
 			n.checkNodeAvailability()
-
 		}
 	}
 }
@@ -256,10 +254,8 @@ func (n *Nodes) checkNodeAvailability() {
 				newOnlineNodes = append(newOnlineNodes, node)
 			}
 			wg.Done()
-
 		}(&wg, node)
 	}
-
 	// Handle timeout
 	timeout := n.heartbeatTimeout
 	if waitTimeout(&wg, time.Duration(timeout)*time.Second) {

--- a/lmd/peer_test.go
+++ b/lmd/peer_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestPeerSource(t *testing.T) {
-
 	waitGroup := &sync.WaitGroup{}
 	shutdownChannel := make(chan bool)
 	connection := Connection{Name: "Test", Source: []string{"http://localhost/test/", "http://clusternode/test"}}

--- a/lmd/response.go
+++ b/lmd/response.go
@@ -289,7 +289,6 @@ func (res *Response) CalculateFinalStats() {
 		}
 		sort.Sort(res)
 	}
-
 }
 
 func finalStatsApply(s *Filter) (res float64) {

--- a/lmd/resultset.go
+++ b/lmd/resultset.go
@@ -15,6 +15,5 @@ func (res *ResultSet) Precompress(offset int, columns *ColumnList) {
 				(*res)[j][i+offset] = interface2stringlarge((*res)[j][i+offset])
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
This fixed building with golangci-lint 1.18.0, by removing some
whitespaces and allowing bigger functions.

Signed-off-by: Jacob Hansen <jhansen@itrsgroup.com>