### PR TITLE
Ensure building with latest golangci-lint works

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,8 @@ linters-settings:
   funlen:
     lines: 150
     statements: 120
+  gocognit:
+    min-complexity: 35
 linters:
   enable-all: true
   disable:
@@ -33,6 +35,7 @@ linters:
     - gochecknoinits
     - dupl
     - goconst
+    - interfacer
   fast: false
 issues:
   max-same-issues: 0

--- a/lmd/column.go
+++ b/lmd/column.go
@@ -226,7 +226,7 @@ type Column struct {
 }
 
 // NewColumn adds a column object.
-func NewColumn(table *Table, name string, storage StorageType, update FetchType, datatype DataType, restrict OptionalFlags, refCol *Column, description string) *Column {
+func NewColumn(table *Table, name string, storage StorageType, update FetchType, datatype DataType, restrict OptionalFlags, refCol *Column, description string) {
 	col := &Column{
 		Table:       table,
 		Name:        name,
@@ -254,7 +254,6 @@ func NewColumn(table *Table, name string, storage StorageType, update FetchType,
 	}
 	table.ColumnsIndex[col.Name] = col
 	table.Columns = append(table.Columns, col)
-	return col
 }
 
 // String returns the string representation of a column list


### PR DESCRIPTION
* Gocognit was recently introduced to golangci-lint. The default limit was
set to 0 causing issues. Set it to 35 to ensure our checks pass.

* disable interfacer

* fix a unused parameter issue