### PR TITLE
Disable wsl linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters:
     - dupl
     - goconst
     - interfacer
+    - wsl
   fast: false
 issues:
   max-same-issues: 0


### PR DESCRIPTION
The Whitespace linter was failing in multiple places. Disable it for
LMD.

Signed-off-by: Jacob Hansen <jhansen@itrsgroup.com>