### PR TITLE
Fix Icinga 2 version regex for v2.11.x

### DIFF
--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -29,7 +29,7 @@ var reResponseHeader = regexp.MustCompile(`^(\d+)\s+(\d+)$`)
 var reHTTPTooOld = regexp.MustCompile(`Can.t locate object method`)
 var reHTTPOMDError = regexp.MustCompile(`<h1>(OMD:.*?)</h1>`)
 var reShinkenVersion = regexp.MustCompile(`\-shinken$`)
-var reIcinga2Version = regexp.MustCompile(`^(r[\d\.-]+|.*\-icinga2)$`)
+var reIcinga2Version = regexp.MustCompile(`^([vr]?(2\.\d+\.\d+).*|.*\-icinga2)$`)
 var reNaemonVersion = regexp.MustCompile(`\-naemon$`)
 
 const (


### PR DESCRIPTION
Seems version format was changed in v2.11+. Update regex based on:
* https://github.com/sni/lmd/issues/92#issuecomment-570952266
* https://github.com/Icinga/icinga2/blob/af7768944a3b95f2a6509f2fb87949044a09cf83/lib/base/utility.cpp#L1184