### PR TITLE
Fix missing comments detection in delta update

### DIFF
--- a/lmd/peer.go
+++ b/lmd/peer.go
@@ -1271,7 +1271,7 @@ func (p *Peer) UpdateDeltaCommentsOrDowntimes(name TableName) (err error) {
 	resIndex := make(map[string]bool)
 	for i := range *res {
 		resRow := &(*res)[i]
-		id := fmt.Sprintf("%v", (*resRow)[0])
+		id := fmt.Sprintf("%d", interface2int64((*resRow)[0]))
 		_, ok := idIndex[id]
 		if !ok {
 			log.Debugf("adding %s with id %s", name.String(), id)


### PR DESCRIPTION
When fetching a list of IDs from the source, the IDs were incorrectly
transformed (with sprintf), marking all comments as missing.

Further, this also caused all comments to be deleted, so we would
essential do a full update every time instead of a delta update.

With this commit we convert to int64 and then use `%d` instead of `%v`
when getting the ID string.