### PR TITLE
Break keep alive connection on EOF

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ require (
 	github.com/lkarlslund/stringdedup v0.2.1
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/prometheus/client_golang v1.4.1
 	github.com/prometheus/procfs v0.0.10 // indirect
@@ -24,4 +26,5 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
 	golang.org/x/tools v0.0.0-20200624060801-dcbf2a9ed15d
+	google.golang.org/appengine v1.4.0 // indirect
 )

--- a/lmd/listener.go
+++ b/lmd/listener.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"io"
 )
 
 const (
@@ -75,6 +76,10 @@ func QueryServer(c net.Conn, conf *Config) error {
 
 		reqs, err := ParseRequests(c)
 		if err != nil {
+			// EOF is OK, we just terminate the connection
+			if err == io.EOF {
+				return nil
+			}
 			if err, ok := err.(net.Error); ok {
 				if keepAlive {
 					log.Debugf("closing keepalive connection from %s", remote)

--- a/lmd/request.go
+++ b/lmd/request.go
@@ -261,6 +261,10 @@ func (req *Request) String() (str string) {
 func NewRequest(b *bufio.Reader, options ParseOptions) (req *Request, size int, err error) {
 	req = &Request{ColumnsHeaders: false, KeepAlive: false}
 	firstLine, err := b.ReadString('\n')
+	// Return if we get an EOF from the first line
+	if err == io.EOF{
+		return
+	}
 	// Network errors will be logged in the listener
 	if _, ok := err.(net.Error); ok {
 		req = nil


### PR DESCRIPTION
When a EOF is sent, LMD did not correctly terminate KeepAlive sessions.
However no more queries would be answered after an EOF. This resulted in
the KeepAlive connection hanging unnecessarily.