### PR TITLE
Add custom variables support for contacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ script:
   -  make clean
   -  make debugbuild
   -  make clean
-  -  '[ $TRAVIS_EVENT_TYPE != "pull_request" ] && make updatedeps'
+  -  'if [ $TRAVIS_EVENT_TYPE != "pull_request" ]; then make updatedeps; fi'
   -  make citest

--- a/Changes
+++ b/Changes
@@ -8,6 +8,7 @@ next:
           - add open connections prometheus metric
           - add optional connection flags, ex. to set a connection to type icinga2
           - fix recovering broken peers
+          - add custom variables support for contacts
 
 1.8.3    Mon Jun  8 11:06:13 CEST 2020
           - improve reload detection with icinga2

--- a/lmd/objects.go
+++ b/lmd/objects.go
@@ -203,6 +203,8 @@ func NewContactsTable() (t *Table) {
 	t = &Table{DefaultSort: []string{"name"}}
 	t.AddColumn("alias", Static, StringCol, "The full name of the contact")
 	t.AddColumn("can_submit_commands", Static, IntCol, "Wether the contact is allowed to submit commands (0/1)")
+	t.AddColumn("custom_variable_names", Static, StringListCol, "A list of all custom variables of the contact")
+	t.AddColumn("custom_variable_values", Dynamic, StringListCol, "A list of the values of all custom variables of the contact")
 	t.AddColumn("email", Static, StringCol, "The email address of the contact")
 	t.AddColumn("host_notification_period", Static, StringCol, "The time period in which the contact will be notified about host problems")
 	t.AddColumn("host_notifications_enabled", Static, IntCol, "Wether the contact will be notified about host problems in general (0/1)")
@@ -210,6 +212,8 @@ func NewContactsTable() (t *Table) {
 	t.AddColumn("pager", Static, StringCol, "The pager address of the contact")
 	t.AddColumn("service_notification_period", Static, StringCol, "The time period in which the contact will be notified about service problems")
 	t.AddColumn("service_notifications_enabled", Static, IntCol, "Wether the contact will be notified about service problems in general (0/1)")
+
+	t.AddExtraColumn("custom_variables", VirtStore, None, CustomVarCol, NoFlags, "A dictionary of the custom variables")
 
 	t.AddPeerInfoColumn("lmd_last_cache_update", Int64Col, "Timestamp of the last LMD update of this object")
 	t.AddPeerInfoColumn("peer_key", StringCol, "Id of this peer")

--- a/lmd/request_test.go
+++ b/lmd/request_test.go
@@ -1030,6 +1030,40 @@ func TestCustomVarCol(t *testing.T) {
 	}
 }
 
+func TestCustomVarColContacts(t *testing.T) {
+	peer := StartTestPeer(1, 2, 9)
+	PauseTestPeers(peer)
+
+	if err := assertEq(1, len(PeerMap)); err != nil {
+		t.Error(err)
+	}
+
+	res, _, err := peer.QueryString("GET contacts\nColumns: custom_variables custom_variable_names custom_variable_values\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val := (*res)[0][1].([]interface{})
+	// custom_variable_names
+	if err = assertEq("FOO", val[0].(string)); err != nil {
+		t.Error(err)
+	}
+	// custom_variable_values
+	val = (*res)[0][2].([]interface{})
+	if err = assertEq("12345", val[0].(string)); err != nil {
+		t.Error(err)
+	}
+	// custom_variables
+	hash := (*res)[0][0].(map[string]interface{})
+	if err = assertEq("12345", hash["FOO"].(string)); err != nil {
+		t.Error(err)
+	}
+
+	if err := StopTestPeer(peer); err != nil {
+		panic(err.Error())
+	}
+}
+
 func TestShouldBeScheduled(t *testing.T) {
 	peer := StartTestPeer(1, 2, 9)
 	PauseTestPeers(peer)

--- a/t/data/contacts.json
+++ b/t/data/contacts.json
@@ -1,2 +1,2 @@
-[["example",1,"nobody@localhost","24x7",0,"example","","24x7",0],
-["authuser",1,"nobody@localhost","24x7",0,"authuser","","24x7",0]]
+[["example",1,["FOO"],[12345],"nobody@localhost","24x7",0,"example","","24x7",0],
+["authuser",1,[],[],"nobody@localhost","24x7",0,"authuser","","24x7",0]]


### PR DESCRIPTION
This will sync the columns `custom_variable_names` and
`custom_variable_values` for the `contacts` table and construct
`custom_variables` map from those.
This is done the same way as for hosts and services.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>