### PR TITLE
Keep services sorted after indexing

### DIFF
--- a/lmd/datastore.go
+++ b/lmd/datastore.go
@@ -274,8 +274,17 @@ func (d *DataStore) tryFilterIndexData(filter []*Filter, fn getPreFilteredDataFi
 		for _, name := range hostlist {
 			services, ok := d.Index2[name]
 			if ok {
-				for _, row := range services {
-					indexedData = append(indexedData, row)
+				// Sort services by description, asc
+				keys := make([]string, len(services))
+				for key := range services {
+					keys = append(keys, key)
+				}
+				sort.Strings(keys)
+				for _, key := range keys {
+					row := services[key]
+					if row != nil {
+						indexedData = append(indexedData, row)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When pre-filtering services by host name the services are fetched as map
and then converted to an array. Since maps are an unordered
data structure the order of the resulting array will essentially be
random. This causes an issue with service queries which follow the
default sort order, the result of these queries are not sorted because
they are expected to already be sorted. So for a simple service query
in the default sort order with a host_name filter which triggers
pre-filtering this combination produces a result where the order of the
services is random.

With this commit the services are sorted by their description, which is
the default order, before returning them in the pre-filtering stage.

Signed-off-by: Erik Sjöström <esjostrom@itrsgroup.com>