### PR TITLE
Add address1 to address6 fields to contacts

### DIFF
--- a/lmd/objects.go
+++ b/lmd/objects.go
@@ -211,6 +211,12 @@ func NewContactsTable() (t *Table) {
 	t.AddColumn("host_notifications_enabled", Static, IntCol, "Wether the contact will be notified about host problems in general (0/1)")
 	t.AddColumn("name", Static, StringCol, "The login name of the contact person")
 	t.AddColumn("pager", Static, StringCol, "The pager address of the contact")
+	t.AddColumn("address1", Static, StringCol, "Additional address information for the contact")
+	t.AddColumn("address2", Static, StringCol, "Additional address information for the contact")
+	t.AddColumn("address3", Static, StringCol, "Additional address information for the contact")
+	t.AddColumn("address4", Static, StringCol, "Additional address information for the contact")
+	t.AddColumn("address5", Static, StringCol, "Additional address information for the contact")
+	t.AddColumn("address6", Static, StringCol, "Additional address information for the contact")
 	t.AddColumn("service_notification_period", Static, StringCol, "The time period in which the contact will be notified about service problems")
 	t.AddColumn("service_notifications_enabled", Static, IntCol, "Wether the contact will be notified about service problems in general (0/1)")
 

--- a/t/data/contacts.json
+++ b/t/data/contacts.json
@@ -13,6 +13,12 @@
     "host_notifications_enabled": 0,
     "name": "example",
     "pager": "",
+    "address1": "",
+    "address2": "",
+    "address3": "",
+    "address4": "",
+    "address5": "",
+    "address6": "",
     "service_notification_period": "24x7",
     "service_notifications_enabled": 0
   },
@@ -26,6 +32,12 @@
     "host_notifications_enabled": 0,
     "name": "authuser",
     "pager": "",
+    "address1": "",
+    "address2": "",
+    "address3": "",
+    "address4": "",
+    "address5": "",
+    "address6": "",
     "service_notification_period": "24x7",
     "service_notifications_enabled": 0
   }


### PR DESCRIPTION
Naemon defines six optional fields for additional address information,
named `address1`, `adress2`, up to `address6`. This commit adds those
six fields to LMD, so that they can be queried for. This aligns the
behavior of LMD with that of Livestatus.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>