### PR TITLE
would there be interest for building static binaries on github?

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -26,6 +26,11 @@ jobs:
     #  if: github.event_name != 'pull_request'
     - run: make citest
     - run: make
+    - name: extract built binary
+      uses: actions/upload-artifact@v2
+      with:
+        name: lmd-go${{ matrix.go-version }}
+        path: lmd/lmd
     - run: make clean
     - run: make build
     - run: make clean


### PR DESCRIPTION
Hi @sni!

Would you be interested in extracting the built binaries from the citest github workflow?

In my usecase I utterly failed at building any go software for internal distribution (getting lmd packaged as an rpm file to install alongside thruk).
Since you're already building the software inside the citest workflow, I tacked the extraction onto this and uploaded the built binaries as a build artifact to the workflow itself.

You can take a look at how this looks on github in the result of my workflow run: https://github.com/klaernie/lmd/actions/runs/2463809794

If you'd like I can also build a workflow to automatically mint a github release with attached binary when you push a tag as you already do.

PS: if you're wondering why I'm not simply using labs.consol.de: SLES15 is not supported there, and our corporate policy requires software built from source anyway. So I'm running my modified action on our internal system, then package the built binary together with our entire thruk and apache configuration as an rpm to distribute to the servers.