### PR TITLE
Accept "python3" OutputFormat

### DIFF
--- a/lmd/request.go
+++ b/lmd/request.go
@@ -100,6 +100,7 @@ const (
 	OutputFormatJSON
 	OutputFormatWrappedJSON
 	OutputFormatPython
+	OutputFormatPython3
 )
 
 // String converts a SortDirection back to the original string.
@@ -111,6 +112,8 @@ func (o *OutputFormat) String() string {
 		return "wrapped_json"
 	case OutputFormatPython:
 		return "python"
+	case OutputFormatPython3:
+		return "python3"
 	}
 	log.Panicf("not implemented")
 	return ""
@@ -859,8 +862,10 @@ func parseOutputFormat(field *OutputFormat, value []byte) (err error) {
 		*field = OutputFormatJSON
 	case "python":
 		*field = OutputFormatPython
+	case "python3":
+		*field = OutputFormatPython3
 	default:
-		err = errors.New("unrecognized outputformat, choose from json, wrapped_json and python")
+		err = errors.New("unrecognized outputformat, choose from json, wrapped_json, python and python3")
 		return
 	}
 	return

--- a/lmd/request_test.go
+++ b/lmd/request_test.go
@@ -263,7 +263,7 @@ func TestResponseErrorsFunc(t *testing.T) {
 		{"GET hosts\nOffset: -1", "bad request: expecting a positive number in: Offset: -1"},
 		{"GET hosts\nSort: name none", "bad request: unrecognized sort direction, must be asc or desc in: Sort: name none"},
 		{"GET hosts\nResponseheader: none", "bad request: unrecognized responseformat, only fixed16 is supported in: Responseheader: none"},
-		{"GET hosts\nOutputFormat: csv: none", "bad request: unrecognized outputformat, choose from json, wrapped_json and python in: OutputFormat: csv: none"},
+		{"GET hosts\nOutputFormat: csv: none", "bad request: unrecognized outputformat, choose from json, wrapped_json, python and python3 in: OutputFormat: csv: none"},
 		{"GET hosts\nStatsAnd: 1", "bad request: not enough filter on stack in: StatsAnd: 1"},
 		{"GET hosts\nStatsOr: 1", "bad request: not enough filter on stack in: StatsOr: 1"},
 		{"GET hosts\nFilter: name", "bad request: filter header must be Filter: <field> <operator> <value> in: Filter: name"},


### PR DESCRIPTION
I needed to make a few minor changes to allow CheckMK to use lmd as a livestatus source.

CheckMK uses `OutputFormat: python3` and these tiny changes seemed to do the trick. It seems to work with these changes applied.

That said, I am obviously slightly curious as to why I didn't need to perform any actual modifications to the data, but there you have it.

Please let me know if I'm missing something glaringly obvious. :)