### PR TITLE
introduce logfile "stdout-journal"

### DIFF
--- a/lmd.ini.example
+++ b/lmd.ini.example
@@ -20,7 +20,15 @@ ListenTimeout = 60
 # set minimum allowed tls version, leave empty to allow all version or specify one of: tls1.0, tls1.1, tls1.2, tls1.3
 TLSMinVersion = "tls1.1"
 
-# daemon will log to stdout if no logfile is set
+# destinations the daemon will log to. Defaults to "stdout"
+# Choose from:
+# - "/var/log/lmd.log" (example)
+#   a literal file name to log to
+# - "stdout" or "stderr"
+#    to log to either standard output or standard error with colorized output
+# - "stdout-journal"
+#    same as stdout, but does not colorize the output and does not print the date/time prefix.
+#    this is more suitable if you connect stdout to a log shipping service like systemd-journald, which will supply the timestamp itself
 #LogFile         = "lmd.log"
 
 # May be Error, Warn, Info, Debug and Trace

--- a/lmd/logging.go
+++ b/lmd/logging.go
@@ -15,8 +15,12 @@ import (
 // LogFormat sets the log format
 var LogFormat string
 
+// DateTimeLogFormat sets the log format for the date/time portion
+var DateTimeLogFormat string
+
 func init() {
-	LogFormat = `[%{Date} %{Time "15:04:05.000"}][%{Severity}][pid:` + fmt.Sprintf("%d", os.Getpid()) + `][%{ShortFile}:%{Line}] %{Message}`
+	DateTimeLogFormat = `[%{Date} %{Time "15:04:05.000"}]`
+	LogFormat = `[%{Severity}][pid:` + fmt.Sprintf("%d", os.Getpid()) + `][%{ShortFile}:%{Line}] %{Message}`
 }
 
 const (
@@ -49,13 +53,16 @@ func InitLogging(conf *Config) {
 	var err error
 	switch {
 	case conf.LogFile == "" || conf.LogFile == "stdout":
-		logFormatter = factorlog.NewStdFormatter(LogColors + LogFormat + LogColorReset)
+		logFormatter = factorlog.NewStdFormatter(LogColors + DateTimeLogFormat + LogFormat + LogColorReset)
 		targetWriter = os.Stdout
 	case strings.EqualFold(conf.LogFile, "stderr"):
-		logFormatter = factorlog.NewStdFormatter(LogColors + LogFormat + LogColorReset)
+		logFormatter = factorlog.NewStdFormatter(LogColors + DateTimeLogFormat + LogFormat + LogColorReset)
 		targetWriter = os.Stderr
-	default:
+	case conf.LogFile == "stdout-journal":
 		logFormatter = factorlog.NewStdFormatter(LogFormat)
+		targetWriter = os.Stdout
+	default:
+		logFormatter = factorlog.NewStdFormatter(DateTimeLogFormat + LogFormat)
 		targetWriter, err = os.OpenFile(conf.LogFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
 	}
 	if err != nil {


### PR DESCRIPTION
This is a very naive attempt at making the log output configurable to not output colors, and skip the date/time, since these would be provided by journald anyway.

I'm pretty sure that this is not the optimal way to implement it, but I wanted to run this in production (I'm currently setting up a local lmd on each of our worker processes, to replace the xinetd-alike unixcat approach of accessing the livestatus unix socket via tcp/ip). In our production environment we use filebeat to transport the journal to a central instance, and I wanted to avoid having to strip ansi-escape-sequences in filebeat.

The better approach probably needs more config options to enable/disable datetime logging and colors separately from each other, or autodetects if the output goes to a terminal to enable colors (`test -t 1`). Once might also argue that native journald logging would be better, but also that's way beyond my golang skills.